### PR TITLE
More sophisticated container search

### DIFF
--- a/ChestOrganizer/Main.cs
+++ b/ChestOrganizer/Main.cs
@@ -1,13 +1,18 @@
 ﻿using HarmonyLib;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
 using Vintagestory.API.Util;
 using Vintagestory.GameContent;
 
 namespace ChestOrganizer;
+
+using ChestList = List<BlockEntityGenericTypedContainer>;
 public class Main : ModSystem {
     public const string ID = "chestorganizer";
     public const string Hotkey = ID + ".openall";
@@ -15,6 +20,8 @@ public class Main : ModSystem {
     private static Harmony harmony;
 
     private ICoreClientAPI api;
+    private RoomRegistry roomSystem;
+    private ModSystemBlockReinforcement reinforcementSystem;
 
     public override void StartPre(ICoreAPI api) 
         => (harmony ??= new Harmony(ID)).PatchAll();
@@ -26,6 +33,9 @@ public class Main : ModSystem {
         this.api = api;
         Patch_ChestDialog.Setup(api);
         Icons.Setup(api);
+        
+        roomSystem = api.ModLoader.GetModSystem<RoomRegistry>();
+        reinforcementSystem = api.ModLoader.GetModSystem<ModSystemBlockReinforcement>();
 
         api.Input.RegisterHotKey(
             Hotkey,
@@ -34,31 +44,132 @@ public class Main : ModSystem {
             HotkeyType.CharacterControls);
         api.Input.SetHotKeyHandler(Hotkey, OpenAll);
     }
+    
+    private bool HasLineOfSightTo(IPlayer player, Vec3d targetPoint)
+    {
+      Vec3d playerEyePos = player.Entity.Pos.XYZ.Add(player.Entity.LocalEyePos);
+
+      // Define a more sophisticated block filter for line of sight
+      BlockFilter blockFilter = (pos, block) => {
+          // Blocks that are air don't need to be considered
+          if (block == null || block.Id == 0)
+              return false;
+          
+          // Target position is always visible
+          if (pos.X == (int)targetPoint.X && pos.Y == (int)targetPoint.Y && pos.Z == (int)targetPoint.Z)
+              return false;
+          
+          // Other containers don't block 
+          if (block is BlockGenericTypedContainer)
+              return false;
+
+          // Allow seeing through transparent blocks
+          if (block.RenderPass == EnumChunkRenderPass.Transparent ||
+              block.RenderPass == EnumChunkRenderPass.BlendNoCull ||
+              block.Replaceable >= 6000)
+          {
+              return false;
+          }
+
+          // If no collision boxes, allow seeing through
+          if (block.CollisionBoxes == null || block.CollisionBoxes.Length == 0)
+              return false;
+
+          // Check collision box volume; if the volume is small (50% or less), allow seeing
+          // through it. This handles chiseled blocks, furniture, fences, etc.
+          var totalVolume = block.CollisionBoxes.Sum(box => (box.X2 - box.X1) * (box.Y2 - box.Y1) * (box.Z2 - box.Z1));
+          if (totalVolume < 0.5f) // 50% threshold
+              return false;
+
+          // Block sight if it's a solid block with substantial collision
+          return true;
+      };
+
+      // Perform the actual raycast
+      var selection = player.Entity.World.InteresectionTester.GetSelectedBlock(
+          playerEyePos,
+          targetPoint,
+          blockFilter
+      );
+
+      // If nothing blocks the ray or it's the target block itself
+      return selection == null ||
+             (selection.Position.X == (int)targetPoint.X &&
+              selection.Position.Y == (int)targetPoint.Y &&
+              selection.Position.Z == (int)targetPoint.Z);
+  }
+  
 
     public bool OpenAll(KeyCombination _) {
+        api.Logger.Audit("Open all blocks");
         var player = api.World.Player;
         if (player.WorldData.CurrentGameMode == EnumGameMode.Creative) return false;
-        var reinforcement = api.ModLoader.GetModSystem<ModSystemBlockReinforcement>();
-
-        float range = player.WorldData.PickingRange + 1;
-        float rangesq = range * range;
-        var eyePos = player.Entity.Pos.XYZ.Add(player.Entity.LocalEyePos - 0.5f);
-        var accessor = api.World.BlockAccessor;
+        
         List<BlockEntityGenericTypedContainer> chests = new();
+        var accessor = api.World.BlockAccessor;
 
-        accessor.WalkBlocks((eyePos - range).AsBlockPos, (eyePos + (range + 1.0f)).AsBlockPos, Step);
-        MergedInventory.MergeRange(chests, api);
+        BlockPos startPos;
+        BlockPos endPos;
+        
+        var eyePos = player.Entity.Pos.XYZ.Add(player.Entity.LocalEyePos - 0.5f);
 
-        return true;
+        // If the player is in a room, use the room to bound scanning and skip the heavy
+        // line of sight checking. If there is a column, wall, etc. in that room that
+        // obscures the storage, we'll still be able to access it. 
+        // 
+        // If the player is NOT in a room, we use a range scan and line of sight checking
+        // to determine what can be opened. This is both more costly and more unpredictable
+        // when in crowded spaces - we are checking visibility to the center of the block,
+        // so if the center of the block is just slightly out of view, it will not open it.
+        var strictCheck = true;
+        var room = roomSystem.GetRoomForPosition(player.Entity.Pos.AsBlockPos);
+        if (room != null && (room.ExitCount == 0 || room.SkylightCount < room.NonSkylightCount))
+        {
+            api.Logger.Debug("Scanning room for chests");
+            startPos = room.Location.Start.AsBlockPos;
+            endPos = room.Location.End.AsBlockPos;
+            strictCheck = false;
+        }
+        else
+        {
+            // Not in an enclosed room; use a ranged scan
+            api.Logger.Debug("Scanning range for chests");
+            var range = player.WorldData.PickingRange + 1;
+            startPos = (eyePos - range).AsBlockPos;
+            endPos = (eyePos + range + 1.0f).AsBlockPos;
+        }
+        
+        // Now that we have our area to scan, do the scan - taking into account anything that
+        // might be blocking the player's ability to interact with the storage
+        var stopwatch = Stopwatch.StartNew();
+        accessor.WalkBlocks(startPos, endPos, (block, x, y, z) =>
+        {
+            var blockPos = new BlockPos(x, y, z);
 
+            // Don't bother with any blocks that aren't a container
+            if (block is not BlockGenericTypedContainer) return;
+            
+            // Don't bother with any containers that are out of reach
+            var blockCenter = new Vec3d(x + 0.5, y + 0.5, z + 0.5);
+            if (player.Entity.Pos.DistanceTo(blockCenter) > 5.1) return;
+            
+            // Try multiple points on the container to check visibility
+            if (strictCheck && !HasLineOfSightTo(player, blockCenter)) return;
 
-        void Step(Block b, int x, int y, int z) {
-            if (eyePos.SquareDistanceTo(x, y, z) > rangesq) return;
-            var entity = accessor.GetBlockEntity<BlockEntityGenericTypedContainer>(new(x, y, z));
-            bool locked = reinforcement.IsLockedForInteract(new(x, y, z), player);
-            if (!locked && (!entity?.Inventory.HasOpened(player) ?? false)) {
+            // Check that there is a block entity of correct type and that reinforcement system
+            // permits access
+            var entity = accessor.GetBlockEntity<BlockEntityGenericTypedContainer>(blockPos);
+            bool locked = reinforcementSystem.IsLockedForInteract(blockPos, player);
+            if (!locked && (!entity?.Inventory.HasOpened(player) ?? false))
+            {
                 chests.Add(entity);
             }
-        }
+        });
+
+        stopwatch.Stop();
+        api.Logger.Debug($"Open all blocks finished in {stopwatch.ElapsedMilliseconds} - Strict mode: {strictCheck}");
+
+        MergedInventory.MergeRange(chests, api);
+        return true;
     }
 }

--- a/ChestOrganizer/Main.cs
+++ b/ChestOrganizer/Main.cs
@@ -123,9 +123,9 @@ public class Main : ModSystem {
         // so if the center of the block is just slightly out of view, it will not open it.
         var strictCheck = true;
         var room = roomSystem.GetRoomForPosition(player.Entity.Pos.AsBlockPos);
-        if (room != null && (room.ExitCount == 0 || room.SkylightCount < room.NonSkylightCount))
+        if (room is { ExitCount: 0 })
         {
-            api.Logger.Debug("Scanning room for chests");
+            api.Logger.Debug($"Scanning room for chests: {room} {room.ExitCount}");
             startPos = room.Location.Start.AsBlockPos;
             endPos = room.Location.End.AsBlockPos;
             strictCheck = false;
@@ -169,7 +169,7 @@ public class Main : ModSystem {
         stopwatch.Stop();
         api.Logger.Debug($"Open all blocks finished in {stopwatch.ElapsedMilliseconds} - Strict mode: {strictCheck}");
 
-        MergedInventory.MergeRange(chests, api);
+        if (chests.Count > 0) MergedInventory.MergeRange(chests, api);
         return true;
     }
 }

--- a/ChestOrganizer/Properties/launchSettings.json
+++ b/ChestOrganizer/Properties/launchSettings.json
@@ -11,6 +11,12 @@
       "executablePath": "dotnet",
       "commandLineArgs": "\"$(VINTAGE_STORY)/VintagestoryServer.dll\" --tracelog --addModPath \"$(ProjectDir)/bin/$(Configuration)/Mods\"",
       "workingDirectory": "$(VINTAGE_STORY)"
+    },
+    "Client-Mac" : {
+      "commandName": "Executable",
+      "executablePath": "bash",
+      "commandLineArgs": "$(ProjectDir)/scripts/runClient.sh $(VINTAGE_STORY) $(ProjectDir) $(Configuration)",
+      "workingDirectory": "$(VINTAGE_STORY)"
     }
   }
 }

--- a/ChestOrganizer/scripts/runClient.sh
+++ b/ChestOrganizer/scripts/runClient.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+VINTAGE_STORY=$1
+PROJECT_DIR=$2
+CONFIGURATION=$3
+
+cd ${VINTAGE_STORY}
+./Vintagestory \
+   --playStyle "creativebuilding" \
+   --openWorld "chestorgcreative" \
+   --addModPath ${PROJECT_DIR}/bin/${CONFIGURATION}/Mods \
+   --dataPath $VS_DEV_DATA \
+   --addOrigin ${PROJECT_DIR}/assets \
+| grep -v  'after final compo   - OpenGL threw an error'


### PR DESCRIPTION
This PR changes the OpenAll function to not allow containers to be opened if they are behind walls or otherwise obscured.

OpenAll now takes into account enclosed rooms and also does visibility checking when outside rooms to ensure obscured blocks are not openable:

- Inside an enclosed room, OpenAll  to open all containers within reach, even if there's columns or other blocks in the way. By definition of a room, this is a slightly cheaper way to ensure only unobscured storage is open.

- In an open space (i.e. NOT room), OpenAll will use container visibility to open all containers within reach. If the center of a container block is NOT visible, it will not be opened. This ensures mostly obstructed storages are not able to be opened.

Tested on 1.20.7, single and multi-player.